### PR TITLE
Simplify Redis interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ Or install it yourself as:
 $ gem install cache_store_redis
 ```
 
-## Environment Variables
-
- - **CACHE_STORE_POOL_SIZE** [Integer] [Default=10] This is the max number of cache_store connections to redis to allow in the connection pool.
- - **CACHE_STORE_POOL_TIMEOUT** [Integer] [Default=1] This is the max number of seconds to wait for a connection from the pool before a timeout occurs.
-
 ## Testing
 
 To run the tests locally, we use Docker to provide both a Ruby and JRuby environment along with a reliable Redis container.

--- a/lib/cache_store_redis/redis_cache_store.rb
+++ b/lib/cache_store_redis/redis_cache_store.rb
@@ -106,7 +106,7 @@ class RedisCacheStore
   # @param key [String] This is the unique key to reference the value being set within this cache store.
   # @param value [Object] This is the value to set within this cache store.
   # @param expires_in [Integer] This is the number of seconds from the current time that this value should expire.
-  def set(key, value, expires_in = 0)
+  def set(key, value, expires_in = nil)
     k = build_key(key)
 
     v = if value.nil? || (value.is_a?(String) && value.strip.empty?)
@@ -116,11 +116,7 @@ class RedisCacheStore
     end
 
     with_client do |client|
-      client.multi do
-        client.set(k, v)
-
-        client.expire(k, expires_in) if expires_in.positive?
-      end
+      client.set(k, v, options = { ex: expires_in })
     end
   end
 
@@ -132,7 +128,7 @@ class RedisCacheStore
   # @param &block [Block] This block is provided to hydrate this cache store with the value for the request key
   # when it is not found.
   # @return [Object] The value for the specified unique key within the cache store.
-  def get(key, expires_in = 0, &block)
+  def get(key, expires_in = nil, &block)
     k = build_key(key)
 
     value = with_client do |client|

--- a/lib/cache_store_redis/version.rb
+++ b/lib/cache_store_redis/version.rb
@@ -1,3 +1,3 @@
 module CacheStoreRedis
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
Condensed down the interaction with Redis to a single command that plays nicely with Redis's SET command's EX option to specify a timeout. This eliminates the need for MULTI and EXPIRY commands.