### PR TITLE
Backport changes v1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /spec/reports/
 /tmp/
 bin/
+.DS_Store
 
 .idea/cache_store.iml
 .idea/inspectionProfiles/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 * Dropped Support for JRuby
 * Improved handling of expiry when calling `set`.
+* Connection Pooling (Added in v1.1.0).

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.3-alpine
 RUN apk add --no-cache --update bash
 
 RUN apk add --no-cache --update --virtual .gem-builddeps make gcc libc-dev ruby-json \
-    && gem install -N oj -v 2.15.0 \
+    && gem install -N oj -v 3.6.10 \
     && gem install -N json -v 2.1.0 \
     && apk del .gem-builddeps
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in cache_store_redis.gemspec
 gemspec
 
-gem 'oj', '2.15.0'
+gem 'oj', '3.6.10'
 gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in cache_store_redis.gemspec
 gemspec
 
-platforms :ruby do
-  gem 'oj', '2.15.0'
-  gem 'pry'
-end
-
-platforms :jruby do
-  gem 'pry-debugger-jruby'
-end
+gem 'oj', '2.15.0'
+gem 'pry'

--- a/cache_store_redis.gemspec
+++ b/cache_store_redis.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'timecop'
 
   spec.add_dependency 'redis'
-
   spec.add_dependency 'oj'
 end

--- a/lib/cache_store_redis.rb
+++ b/lib/cache_store_redis.rb
@@ -5,5 +5,7 @@ require 'cache_store_redis/version'
 require 'redis'
 require 'securerandom'
 
+require_relative 'cache_store_redis/redis_connection'
+require_relative 'cache_store_redis/redis_connection_pool'
 require_relative 'cache_store_redis/redis_cache_store'
 require_relative 'cache_store_redis/optional_redis_cache_store'

--- a/lib/cache_store_redis.rb
+++ b/lib/cache_store_redis.rb
@@ -4,6 +4,8 @@ require 'thread'
 require 'cache_store_redis/version'
 require 'redis'
 require 'securerandom'
+require 'oj'
+require 'logger'
 
 require_relative 'cache_store_redis/redis_connection'
 require_relative 'cache_store_redis/redis_connection_pool'

--- a/lib/cache_store_redis/optional_redis_cache_store.rb
+++ b/lib/cache_store_redis/optional_redis_cache_store.rb
@@ -37,10 +37,7 @@ class OptionalRedisCacheStore
   def optional_get(key, expires_in = 0)
     redis_store.get(key, expires_in)
   rescue => e
-    @logger.error(
-      "[#{self.class}] - An error occurred requesting data from the cache. " \
-"Key: #{key} | Error: #{e.message} | Backtrace: #{e.backtrace}"
-    )
+    handle_error(e, 'requesting data from the cache')
     nil
   end
 
@@ -58,48 +55,42 @@ class OptionalRedisCacheStore
   def set(key, value, expires_in = 0)
     redis_store.set(key, value, expires_in)
   rescue => e
-    @logger.error(
-      "[#{self.class}] - An error occurred storing data in the cache. " \
-"Key: #{key} | Error: #{e.message} | Backtrace: #{e.backtrace}"
-    )
+    handle_error(e, 'storing data in the cache')
   end
 
   def remove(key)
     redis_store.remove(key)
   rescue => e
-    @logger.error(
-      "[#{self.class}] - An error occurred removing data from the cache. " \
-"Key: #{key} | Error: #{e.message} | Backtrace: #{e.backtrace}"
-    )
+    handle_error(e, 'removing data from the cache')
   end
 
   def exist?(key)
     redis_store.exist?(key)
   rescue => e
-    @logger.error(
-      "[#{self.class}] - An error occurred checking if a key exists in the cache. " \
-"Key: #{key} | Error: #{e.message} | Backtrace: #{e.backtrace}"
-    )
+    handle_error(e, 'checking if a key exists in the cache')
     false
   end
 
   def ping
     redis_store.ping
   rescue => e
-    @logger.error(
-      "[#{self.class}] - An error occurred checking pinging the cache. " \
-"Error: #{e.message} | Backtrace: #{e.backtrace}"
-    )
+    handle_error(e, 'pinging the cache')
     false
   end
 
   def shutdown
     redis_store.shutdown
   rescue => e
-    @logger.error(
-      "[#{self.class}] - An error occurred checking shutting down the connection pool. " \
-"Error: #{e.message} | Backtrace: #{e.backtrace}"
-    )
+    handle_error(e, 'shutting down the connection pool')
     false
+  end
+
+  private
+
+  def handle_error(ex, msg)
+    @logger.error do
+      "[#{self.class}] - An error occurred #{msg}. " \
+      "Error: #{ex.message} | Backtrace: #{ex.backtrace}"
+    end
   end
 end

--- a/lib/cache_store_redis/optional_redis_cache_store.rb
+++ b/lib/cache_store_redis/optional_redis_cache_store.rb
@@ -1,5 +1,3 @@
-require 'logger'
-
 # This class is used to define a redis cache store that logs failures as warnings but does not raise errors for
 # cache connections
 class OptionalRedisCacheStore
@@ -7,7 +5,7 @@ class OptionalRedisCacheStore
     @cache_store = RedisCacheStore.new(namespace, config)
     @logger = logger || Logger.new(STDOUT)
   end
-  
+
   def redis_store
     @cache_store
   end

--- a/lib/cache_store_redis/optional_redis_cache_store.rb
+++ b/lib/cache_store_redis/optional_redis_cache_store.rb
@@ -94,4 +94,14 @@ class OptionalRedisCacheStore
     )
     false
   end
+
+  def shutdown
+    redis_store.shutdown
+  rescue => e
+    @logger.error(
+      "[#{self.class}] - An error occurred checking shutting down the connection pool. " \
+"Error: #{e.message} | Backtrace: #{e.backtrace}"
+    )
+    false
+  end
 end

--- a/lib/cache_store_redis/redis_cache_store.rb
+++ b/lib/cache_store_redis/redis_cache_store.rb
@@ -1,13 +1,14 @@
 # This class is used to implement a redis cache store.
 class RedisCacheStore
   def initialize(namespace = nil, config = nil)
+    @connection_pool = RedisConnectionPool.new(config)
+
     unless RUBY_PLATFORM == 'java'
       require 'oj'
     end
 
     @namespace = namespace
     @config = config
-    @queue = Queue.new
 
     @connections_created = 0
     @connections_in_use = 0
@@ -15,26 +16,8 @@ class RedisCacheStore
     @enable_stats = false
   end
 
-  def enable_stats=(value)
-    @enable_stats = value
-  end
-
-  def increment_created_stat
-    @mutex.synchronize do
-      @connections_created += 1
-    end
-  end
-
-  def increment_using_stat
-    @mutex.synchronize do
-      @connections_in_use += 1
-    end
-  end
-
-  def decrement_using_stat
-    @mutex.synchronize do
-      @connections_in_use -= 1
-    end
+  def connection_pool
+    @connection_pool
   end
 
   # This method is called to configure the connection to the cache store.
@@ -61,43 +44,17 @@ class RedisCacheStore
     @config[:connect_timeout] = connect_timeout
     @config[:read_timeout] = read_timeout
     @config[:write_timeout] = write_timeout
-  end
-
-  def fetch_client
-    begin
-      @queue.pop(true)
-    rescue
-      increment_created_stat
-      Redis.new(@config)
-    end
+    connection_pool.config = @config
   end
 
   def clean
-    while @queue.length.positive?
-      client = @queue.pop(true)
-      client.close
-    end
+    connection_pool.shutdown
   end
-
-  def log_stats
-    return unless @enable_stats == true
-    S1Logging.logger.debug do
-      "[#{self.class}] - REDIS Connection Stats. Process: #{Process.pid} | " \
-"Created: #{@connections_created} | Pending: #{@queue.length} | In use: #{@connections_in_use}"
-    end
-  end
+  alias_method :shutdown, :clean
 
   def with_client
-    log_stats
-    begin
-      client = fetch_client
-      increment_using_stat
-      log_stats
-      yield client
-    ensure
-      @queue.push(client)
-      decrement_using_stat
-      log_stats
+    connection_pool.with_connection do |connection|
+      yield connection
     end
   end
 
@@ -106,7 +63,7 @@ class RedisCacheStore
   # @param key [String] This is the unique key to reference the value being set within this cache store.
   # @param value [Object] This is the value to set within this cache store.
   # @param expires_in [Integer] This is the number of seconds from the current time that this value should expire.
-  def set(key, value, expires_in = nil)
+  def set(key, value, expires_in = 3_600)
     k = build_key(key)
 
     v = if value.nil? || (value.is_a?(String) && value.strip.empty?)
@@ -116,7 +73,11 @@ class RedisCacheStore
     end
 
     with_client do |client|
-      client.set(k, v, options = { ex: expires_in })
+      client.multi do
+        client.set(k, v)
+
+        client.expire(k, expires_in) if expires_in.positive?
+      end
     end
   end
 
@@ -128,7 +89,7 @@ class RedisCacheStore
   # @param &block [Block] This block is provided to hydrate this cache store with the value for the request key
   # when it is not found.
   # @return [Object] The value for the specified unique key within the cache store.
-  def get(key, expires_in = nil, &block)
+  def get(key, expires_in = 0, &block)
     k = build_key(key)
 
     value = with_client do |client|

--- a/lib/cache_store_redis/redis_cache_store.rb
+++ b/lib/cache_store_redis/redis_cache_store.rb
@@ -3,10 +3,6 @@ class RedisCacheStore
   def initialize(namespace = nil, config = nil)
     @connection_pool = RedisConnectionPool.new(config)
 
-    unless RUBY_PLATFORM == 'java'
-      require 'oj'
-    end
-
     @namespace = namespace
     @config = config
 
@@ -141,19 +137,11 @@ class RedisCacheStore
   private
 
   def serialize(object)
-    if RUBY_PLATFORM == 'java'
-      Marshal::dump(object)
-    else
-      Oj.dump(object)
-    end
+    Oj.dump(object)
   end
 
   def deserialize(object)
-    if RUBY_PLATFORM == 'java'
-      Marshal::load(object)
-    else
-      Oj.load(object)
-    end
+    Oj.load(object)
   end
 
   def build_key(key)

--- a/lib/cache_store_redis/redis_connection.rb
+++ b/lib/cache_store_redis/redis_connection.rb
@@ -1,0 +1,29 @@
+class RedisConnection
+  attr_accessor :created
+  attr_accessor :client
+
+  def initialize(config)
+    self.client = Redis.new(config)
+    self.created = Time.now
+  end
+
+  # This method is called to determine if this connection has been open for longer than the keep alive timeout or not.
+  def expired?
+    return false if self.created.nil?
+    Time.now >= (self.created + keep_alive_timeout)
+  end
+
+  def open
+    self.created = Time.now if self.created.nil?
+  end
+
+  def close
+    self.client.close
+    self.created = nil
+  end
+
+  # This method is called to get the keep alive timeout value to use for this connection.
+  def keep_alive_timeout
+    Float(ENV['REDIS_KEEP_ALIVE_TIMEOUT'] ||  30)
+  end
+end

--- a/lib/cache_store_redis/redis_connection_pool.rb
+++ b/lib/cache_store_redis/redis_connection_pool.rb
@@ -1,0 +1,84 @@
+# This class is used to define a pool of re-usable redis connections.
+class RedisConnectionPool
+  attr_accessor :config
+
+  def initialize(namespace = nil, config = nil)
+    @namespace = namespace
+    @config = config
+    @queue = Queue.new
+    @connections = []
+    @mutex = Mutex.new
+    @monitor_thread = Thread.new do
+      loop do
+        sleep(1)
+        @mutex.synchronize do
+          connections.select { |con| con.expired? }.each do |con|
+            con.close
+          end
+        end
+      end
+    end
+  end
+
+  # This method is called to get the namespace for redis keys.
+  def namespace
+    @namespace
+  end
+
+  # This method is called to get the idle connection queue for this pool.
+  def queue
+    @queue
+  end
+
+  # This method is called to fetch a connection from the queue or create a new connection if no idle connections
+  # are available.
+  def fetch_connection
+    queue.pop(true)
+  rescue
+    RedisConnection.new(config)
+  end
+
+  # This method is called to checkout a connection from the pool before use.
+  def check_out
+    connection = nil
+    @mutex.synchronize do
+      connection = fetch_connection
+      connections.delete(connection)
+      connection.open
+    end
+    connection
+  end
+
+  # This method is called to checkin a connection to the pool after use.
+  def check_in(connection)
+    if connection.expired?
+      connection.close
+    end
+    @mutex.synchronize do
+      connections.push(connection)
+      queue.push(connection)
+    end
+  end
+
+  # This method is called to use a connection from this pool.
+  def with_connection
+    connection = check_out
+    return yield connection.client
+  ensure
+    check_in(connection)
+  end
+
+  # This method is called to get an array of idle connections in this pool.
+  def connections
+    @connections
+  end
+
+  def shutdown
+    connections.each do |con|
+      con.client.close
+    end
+    @connections = []
+    @monitor_thread.kill
+    @queue = Queue.new
+  end
+end

--- a/spec/cache_store_redis_spec.rb
+++ b/spec/cache_store_redis_spec.rb
@@ -10,7 +10,6 @@ describe RedisCacheStore do
 
   describe "#set" do
     it 'should add a string to the cache store and retrieve it' do
-
       key = SecureRandom.uuid
       value = 'value123'
       @cache_store.set(key, value)
@@ -18,11 +17,9 @@ describe RedisCacheStore do
       v = @cache_store.get(key)
 
       expect(v).to eq(value)
-
     end
 
     it 'should add an object to the cache store and retrieve it' do
-
       key = SecureRandom.uuid
       value = TestObject.new
       value.text = 'abc123'
@@ -35,11 +32,9 @@ describe RedisCacheStore do
       expect(v.class).to eq(TestObject)
       expect(v.text).to eq(value.text)
       expect(v.numeric).to eq(value.numeric)
-
     end
 
     it 'should run the hydration block when the requested key does not exist in the cache' do
-
       key = SecureRandom.uuid
 
       v = @cache_store.get(key) do

--- a/spec/redis_connection_spec.rb
+++ b/spec/redis_connection_spec.rb
@@ -1,0 +1,84 @@
+describe RedisConnection do
+  let(:config) { {} }
+
+  subject do
+    described_class.new(config)
+  end
+
+  describe '#initialize' do
+    it 'creates a redis client' do
+      expect(subject.client).to be_instance_of(Redis)
+    end
+
+    it 'sets a created timestamp' do
+      Timecop.freeze(Time.now) do
+        expect(subject.created).to eq(Time.now)
+      end
+    end
+  end
+
+  describe '#expired?' do
+    context 'when created is nil' do
+      it 'returns false' do
+        subject.created = nil
+        expect(subject.expired?).to eq(false)
+      end
+    end
+
+    context 'when current time is greater than the created time + keep alive timeout' do
+      it 'returns true' do
+        subject.open
+
+        Timecop.freeze(Time.now + 60) do
+          expect(subject.expired?).to eq(true)
+        end
+      end
+    end
+
+    context 'when current time is less than the created time + keep alive timeout' do
+      it 'returns false' do
+        expect(subject.expired?).to eq(false)
+      end
+    end
+  end
+
+  describe '#open' do
+    it 'ensures that .created is set' do
+      subject.created = nil
+      subject.open
+      expect(subject.created).to_not be_nil
+    end
+  end
+
+  describe '#close' do
+    it 'sets created to nil' do
+      subject.close
+      expect(subject.created).to be_nil
+    end
+
+    it 'calls close on the Redis client' do
+      expect(subject.client).to receive(:close)
+      subject.close
+    end
+  end
+
+  describe '#keep_alive_timeout' do
+    it 'returns a default keep alive of 30.0' do
+      expect(subject.keep_alive_timeout).to eq(30.0)
+    end
+
+    context 'when REDIS_KEEP_ALIVE_TIMEOUT is set' do
+      before do
+        ENV['REDIS_KEEP_ALIVE_TIMEOUT'] = "400"
+      end
+
+      it 'returns the value of REDIS_KEEP_ALIVE_TIMEOUT as a float' do
+        expect(subject.keep_alive_timeout).to eq(400.0)
+      end
+
+      after do
+        ENV['REDIS_KEEP_ALIVE_TIMEOUT'] = nil
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,12 @@ SimpleCov.start do
   add_filter 'spec/'
 end
 
+require 'timecop'
 require 'pry'
 require_relative 'test_object'
 require_relative '../lib/cache_store_redis'
+
+Timecop.safe_mode = true
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Changes released as v1.1.0 from https://github.com/Sage/cache_store/pull/16 were missed when we split https://github.com/Sage/cache_store into https://github.com/Sage/cache_store and https://github.com/Sage/cache_store_redis