### PR TITLE
Enforce default TTL always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.1.0
+
+* Set method enforces a default TTL of `3_600` if the `expires_in` option is not provided, or is invalid.
+* Set method enforces the TTL to always be an Integer.
+
 # v2.0.0
 
 * Dropped Support for JRuby

--- a/lib/cache_store_redis/version.rb
+++ b/lib/cache_store_redis/version.rb
@@ -1,3 +1,3 @@
 module CacheStoreRedis
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/spec/cache_store_redis_spec.rb
+++ b/spec/cache_store_redis_spec.rb
@@ -9,6 +9,35 @@ describe RedisCacheStore do
   end
 
   describe "#set" do
+    context 'expires_in' do
+      let(:key) { SecureRandom.uuid }
+      let(:value) { 'SomeValue' }
+
+      it 'will always set a default TTL if one is not provided' do
+        expect_any_instance_of(Redis).to receive(:set).with("test:#{key}", "\"#{value}\"")
+        expect_any_instance_of(Redis).to receive(:expire).with("test:#{key}", 3_600)
+        @cache_store.set(key, value)
+      end
+
+      it 'will always set a default TTL if an invalid one is provided' do
+        expect_any_instance_of(Redis).to receive(:set).with("test:#{key}", "\"#{value}\"")
+        expect_any_instance_of(Redis).to receive(:expire).with("test:#{key}", 3_600)
+        @cache_store.set(key, value, -200)
+      end
+
+      it 'will always set a default TTL if an invalid one is provided' do
+        expect_any_instance_of(Redis).to receive(:set).with("test:#{key}", "\"#{value}\"")
+        expect_any_instance_of(Redis).to receive(:expire).with("test:#{key}", 3_600)
+        @cache_store.set(key, value, 0.456)
+      end
+
+      it 'will always force the TTL to be an integer' do
+        expect_any_instance_of(Redis).to receive(:set).with("test:#{key}", "\"#{value}\"")
+        expect_any_instance_of(Redis).to receive(:expire).with("test:#{key}", 20)
+        @cache_store.set(key, value, 20.123)
+      end
+    end
+
     it 'should add a string to the cache store and retrieve it' do
       key = SecureRandom.uuid
       value = 'value123'


### PR DESCRIPTION
* Set method enforces a default TTL of `3_600` if the `expires_in` option is not provided, or is invalid.
* Set method enforces the TTL to always be an Integer.