### PR TITLE
ENG-1854 Fix handling of config passed to RedisCacheStore constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.1.1
+
+* Fix handling of config passed to RedisCacheStore constructor
+
 # v2.1.0
 
 * Set method enforces a default TTL of `3_600` if the `expires_in` option is not provided, or is invalid.

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ $ gem install cache_store_redis
 
 ## Testing
 
-To run the tests locally, we use Docker to provide both a Ruby and JRuby environment along with a reliable Redis container.
+To run the tests locally, we use Docker to provide a Ruby container.
 
 ### Setup Images:
 
-> This builds the Ruby and JRuby docker images.
+> This builds the Ruby docker image.
 
 ```bash
 cd script
@@ -44,7 +44,7 @@ cd script
 
 ### Run Tests:
 
-> This executes the test suite in both Ruby and JRuby.
+> This executes the test suite
 
 ```bash
 cd script

--- a/lib/cache_store_redis/redis_cache_store.rb
+++ b/lib/cache_store_redis/redis_cache_store.rb
@@ -4,7 +4,7 @@ class RedisCacheStore
   DEFAULT_TTL = 3_600
 
   def initialize(namespace = nil, config = nil)
-    @connection_pool = RedisConnectionPool.new(config)
+    @connection_pool = RedisConnectionPool.new(namespace, config)
 
     @namespace = namespace
     @config = config

--- a/lib/cache_store_redis/version.rb
+++ b/lib/cache_store_redis/version.rb
@@ -1,3 +1,3 @@
 module CacheStoreRedis
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end


### PR DESCRIPTION
The `RedisConnectionPool` class constructor accepts two positional arguments but up to now the `RedisCacheStore` class initialised it with only the second one.