### PR TITLE
Update the redis .multi code to remove the warnings in the logs

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,6 +6,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.2', '3.1', '3.0']
+
     services:
       redis:
         image: redis:alpine
@@ -18,10 +23,12 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.4
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.4.2
+* Update to `set` to use .multi correctly - the yield block now takes a parameter and calls that with the commands to execute which will then correctly be called in a multi block to redis
+
 # v2.2.0
 
 * Alias `#get`, `#set`, and `#remove` to `#read`, `#write`, and `#delete`, so that `RedisCacheStore` and `OptionalRedisCacheStore` can be used anywhere that expects a `#read`, `#write`, `#delete` API e.g. `faraday-http-cache`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-buster
+FROM ruby:3.2
 
 ARG BUNDLE_SAGEONEGEMS__JFROG__IO
 

--- a/cache_store_redis.gemspec
+++ b/cache_store_redis.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/sage/cache_store'
   spec.license       = 'MIT'
 
+  spec.required_ruby_version = '>= 3.0'
+
   spec.files         = Dir.glob("{bin,lib}/**/**/**")
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/cache_store_redis.gemspec
+++ b/cache_store_redis.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/sage/cache_store'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 3.0'
-
   spec.files         = Dir.glob("{bin,lib}/**/**/**")
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/lib/cache_store_redis/redis_cache_store.rb
+++ b/lib/cache_store_redis/redis_cache_store.rb
@@ -75,10 +75,10 @@ class RedisCacheStore
     expire_value = expiry_int.positive? ? expiry_int : Integer(DEFAULT_TTL)
 
     with_client do |client|
-      client.multi do
-        client.set(k, v)
+      client.multi do |transaction|
+        transaction.set(k, v)
 
-        client.expire(k, expire_value)
+        transaction.expire(k, expire_value)
       end
     end
   end

--- a/lib/cache_store_redis/version.rb
+++ b/lib/cache_store_redis/version.rb
@@ -1,3 +1,3 @@
 module CacheStoreRedis
-  VERSION = '2.4.1'
+  VERSION = '2.4.2'
 end

--- a/spec/cache_store_redis_spec.rb
+++ b/spec/cache_store_redis_spec.rb
@@ -8,26 +8,26 @@ RSpec.shared_examples '#set' do |method_name|
     let(:value) { 'SomeValue' }
 
     it 'will always set a default TTL if one is not provided' do
-      expect_any_instance_of(Redis).to receive(:set).with("test:#{key}", "\"#{value}\"")
-      expect_any_instance_of(Redis).to receive(:expire).with("test:#{key}", 3_600)
+      expect_any_instance_of(Redis::MultiConnection).to receive(:set).with("test:#{key}", "\"#{value}\"")
+      expect_any_instance_of(Redis::MultiConnection).to receive(:expire).with("test:#{key}", 3_600)
       subject.public_send(method_name, key, value)
     end
 
     it 'will always set a default TTL if an invalid one is provided' do
-      expect_any_instance_of(Redis).to receive(:set).with("test:#{key}", "\"#{value}\"")
-      expect_any_instance_of(Redis).to receive(:expire).with("test:#{key}", 3_600)
+      expect_any_instance_of(Redis::MultiConnection).to receive(:set).with("test:#{key}", "\"#{value}\"")
+      expect_any_instance_of(Redis::MultiConnection).to receive(:expire).with("test:#{key}", 3_600)
       subject.public_send(method_name, key, value, -200)
     end
 
     it 'will always set a default TTL if an invalid one is provided' do
-      expect_any_instance_of(Redis).to receive(:set).with("test:#{key}", "\"#{value}\"")
-      expect_any_instance_of(Redis).to receive(:expire).with("test:#{key}", 3_600)
+      expect_any_instance_of(Redis::MultiConnection).to receive(:set).with("test:#{key}", "\"#{value}\"")
+      expect_any_instance_of(Redis::MultiConnection).to receive(:expire).with("test:#{key}", 3_600)
       subject.public_send(method_name, key, value, 0.456)
     end
 
     it 'will always force the TTL to be an integer' do
-      expect_any_instance_of(Redis).to receive(:set).with("test:#{key}", "\"#{value}\"")
-      expect_any_instance_of(Redis).to receive(:expire).with("test:#{key}", 20)
+      expect_any_instance_of(Redis::MultiConnection).to receive(:set).with("test:#{key}", "\"#{value}\"")
+      expect_any_instance_of(Redis::MultiConnection).to receive(:expire).with("test:#{key}", 20)
       subject.public_send(method_name, key, value, 20.123)
     end
   end


### PR DESCRIPTION
https://jira.sage.com/browse/ENG-2692

As per the warnings we're now passing a parameter into the block that should be used instead of calling the redis client.

https://github.com/redis/redis-rb/blob/08f3e18db95ab4f3980d35a22f16904b53bb505d/README.md#executing-commands-atomically

Upgraded the ruby version to 3.2, and added a matrix of ruby versions  3.0 - 3.2 to the rspecs.

This version now locks minimum ruby version to 3.0 and above