### PR TITLE
Remove JRuby from workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,15 +21,4 @@ jobs:
       - name: Publish to RubyGems
         run: |
           gem build cache_store_redis.gemspec
-          gem push cache_store_redis-*.gem
-
-      - name: Set up JRuby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: jruby
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - run: jruby -S gem build cache_store_redis.gemspec
-
-      - name: Publish to RubyGems
-        run: |
-          gem push cache_store_redis-*.gem
+          gem push cache_store_redis.gem

--- a/lib/cache_store_redis/version.rb
+++ b/lib/cache_store_redis/version.rb
@@ -1,3 +1,3 @@
 module CacheStoreRedis
-  VERSION = '2.4.4'.freeze
+  VERSION = '2.4.2'.freeze
 end


### PR DESCRIPTION
We switched from Jruby to MRI Ruby so having JRuby in workflow is unnecessary.
https://github.com/Sage/s1_ab_service/pull/113