### PR TITLE
Use wildcard pattern to correctly identify version number in the gem filename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
     types:
       - "created"
 
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -21,4 +22,4 @@ jobs:
       - name: Publish to RubyGems
         run: |
           gem build cache_store_redis.gemspec
-          gem push cache_store_redis.gem
+          gem push cache_store_redis-*.gem

--- a/lib/cache_store_redis/version.rb
+++ b/lib/cache_store_redis/version.rb
@@ -1,3 +1,3 @@
 module CacheStoreRedis
-  VERSION = '2.4.2'.freeze
+  VERSION = '2.4.2.rc1'.freeze
 end

--- a/lib/cache_store_redis/version.rb
+++ b/lib/cache_store_redis/version.rb
@@ -1,3 +1,3 @@
 module CacheStoreRedis
-  VERSION = '2.4.2.rc1'.freeze
+  VERSION = '2.4.2'.freeze
 end


### PR DESCRIPTION
Tested against [v2.4.2.rc1](https://github.com/Sage/cache_store_redis/actions/runs/21991826319/job/63544805020#step:4:31) tag and was able to successfully publish the gem.